### PR TITLE
feat(script): add card import func with sample data for test

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -100,6 +100,12 @@ tasks:
     cmds:
       - docker-compose exec mysql mysql -u user -ppassword iris-db
 
+  db:import-cards:
+    desc: Import sample card hashes into database
+    cmds:
+      - echo ">> Importing card hashes from sample data..."
+      - docker-compose exec api python -m scripts.card_importer.import_cards
+
   setup-hooks:
       desc: Set up Git hooks without local dependencies
       cmds:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -15,7 +15,7 @@ class Settings(BaseSettings):
 
     class Config:
         env_file = ".env"
-        extra = "ignore"  # Add this line to ignore extra fields
+        extra = "ignore"
 
 
 settings = Settings()

--- a/scripts/card_importer/cards_data.json
+++ b/scripts/card_importer/cards_data.json
@@ -1,0 +1,162 @@
+[
+	{
+		"id" : "base1-1",
+		"image_large" : "https://images.pokemontcg.io/base1/1_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/1.png"
+	},
+	{
+		"id" : "base1-10",
+		"image_large" : "https://images.pokemontcg.io/base1/10_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/10.png"
+	},
+	{
+		"id" : "base1-100",
+		"image_large" : "https://images.pokemontcg.io/base1/100_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/100.png"
+	},
+	{
+		"id" : "base1-101",
+		"image_large" : "https://images.pokemontcg.io/base1/101_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/101.png"
+	},
+	{
+		"id" : "base1-102",
+		"image_large" : "https://images.pokemontcg.io/base1/102_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/102.png"
+	},
+	{
+		"id" : "base1-11",
+		"image_large" : "https://images.pokemontcg.io/base1/11_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/11.png"
+	},
+	{
+		"id" : "base1-12",
+		"image_large" : "https://images.pokemontcg.io/base1/12_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/12.png"
+	},
+	{
+		"id" : "base1-13",
+		"image_large" : "https://images.pokemontcg.io/base1/13_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/13.png"
+	},
+	{
+		"id" : "base1-14",
+		"image_large" : "https://images.pokemontcg.io/base1/14_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/14.png"
+	},
+	{
+		"id" : "base1-15",
+		"image_large" : "https://images.pokemontcg.io/base1/15_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/15.png"
+	},
+	{
+		"id" : "base1-16",
+		"image_large" : "https://images.pokemontcg.io/base1/16_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/16.png"
+	},
+	{
+		"id" : "base1-17",
+		"image_large" : "https://images.pokemontcg.io/base1/17_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/17.png"
+	},
+	{
+		"id" : "base1-18",
+		"image_large" : "https://images.pokemontcg.io/base1/18_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/18.png"
+	},
+	{
+		"id" : "base1-19",
+		"image_large" : "https://images.pokemontcg.io/base1/19_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/19.png"
+	},
+	{
+		"id" : "base1-2",
+		"image_large" : "https://images.pokemontcg.io/base1/2_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/2.png"
+	},
+	{
+		"id" : "base1-20",
+		"image_large" : "https://images.pokemontcg.io/base1/20_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/20.png"
+	},
+	{
+		"id" : "base1-21",
+		"image_large" : "https://images.pokemontcg.io/base1/21_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/21.png"
+	},
+	{
+		"id" : "base1-22",
+		"image_large" : "https://images.pokemontcg.io/base1/22_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/22.png"
+	},
+	{
+		"id" : "base1-23",
+		"image_large" : "https://images.pokemontcg.io/base1/23_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/23.png"
+	},
+	{
+		"id" : "base1-24",
+		"image_large" : "https://images.pokemontcg.io/base1/24_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/24.png"
+	},
+	{
+		"id" : "base1-25",
+		"image_large" : "https://images.pokemontcg.io/base1/25_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/25.png"
+	},
+	{
+		"id" : "base1-26",
+		"image_large" : "https://images.pokemontcg.io/base1/26_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/26.png"
+	},
+	{
+		"id" : "base1-27",
+		"image_large" : "https://images.pokemontcg.io/base1/27_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/27.png"
+	},
+	{
+		"id" : "base1-28",
+		"image_large" : "https://images.pokemontcg.io/base1/28_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/28.png"
+	},
+	{
+		"id" : "base1-29",
+		"image_large" : "https://images.pokemontcg.io/base1/29_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/29.png"
+	},
+	{
+		"id" : "base1-3",
+		"image_large" : "https://images.pokemontcg.io/base1/3_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/3.png"
+	},
+	{
+		"id" : "base1-30",
+		"image_large" : "https://images.pokemontcg.io/base1/30_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/30.png"
+	},
+	{
+		"id" : "base1-31",
+		"image_large" : "https://images.pokemontcg.io/base1/31_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/31.png"
+	},
+	{
+		"id" : "base1-32",
+		"image_large" : "https://images.pokemontcg.io/base1/32_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/32.png"
+	},
+	{
+		"id" : "base1-33",
+		"image_large" : "https://images.pokemontcg.io/base1/33_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/33.png"
+	},
+	{
+		"id" : "base1-34",
+		"image_large" : "https://images.pokemontcg.io/base1/34_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/34.png"
+	},
+	{
+		"id" : "base1-35",
+		"image_large" : "https://images.pokemontcg.io/base1/35_hires.png",
+		"image_small" : "https://images.pokemontcg.io/base1/35.png"
+	}
+]

--- a/scripts/card_importer/import_cards.py
+++ b/scripts/card_importer/import_cards.py
@@ -1,0 +1,97 @@
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+
+from app.db.models.card_hash import CardHash
+from app.db.session import SessionLocal, init_db
+from app.services.image_hash_service import image_hash_service
+
+# Add project root to path so we can import app modules
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+async def import_cards(json_file=None, small_images=True):
+    """
+    Import card hashes from JSON file into database.
+
+    Args:
+        json_file: Path to the JSON file containing card data
+        small_images: Whether to use small images (faster) or large images
+            (better quality)
+    """
+    # Set default JSON file path if not provided
+    if json_file is None:
+        json_file = Path(__file__).parent / "cards_data.json"
+
+    logging.info(f"Reading cards from {json_file}")
+
+    # Initialize the database if needed
+    init_db()
+
+    # Open JSON file
+    try:
+        with open(json_file, "r") as f:
+            cards = json.load(f)
+    except FileNotFoundError:
+        logging.error(f"File not found: {json_file}")
+        return
+
+    # Create session
+    db = SessionLocal()
+
+    try:
+        # Get existing cards to avoid duplicates
+        existing_cards = {card.id for card in db.query(CardHash.id).all()}
+
+        for i, card in enumerate(cards):
+            card_id = card["id"]
+
+            # Skip if already exists
+            if card_id in existing_cards:
+                logging.info(f"Card {card_id} already exists in database, skipping...")
+                continue
+
+            # Choose image URL based on size preference
+            image_url = card["image_small"] if small_images else card["image_large"]
+
+            try:
+                logging.info(f"Processing card {i+1}/{len(cards)}: {card_id}")
+
+                # Calculate hash using our service
+                hash_value = await image_hash_service.hash_from_url(image_url)
+
+                # Store in database
+                card_hash = CardHash(id=card_id, hash=hash_value)
+                db.add(card_hash)
+                db.commit()
+
+                logging.info(f"Saved hash for {card_id}")
+
+            except Exception as e:
+                db.rollback()
+                logging.error(f"Error processing card {card_id}: {str(e)}")
+                continue
+
+    except Exception as e:
+        logging.error(f"Error during import: {str(e)}")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
+
+    # Get command line argument for image size
+    use_small = True
+    if len(sys.argv) > 1 and sys.argv[1].lower() == "large":
+        use_small = False
+        logging.info("Using large images (slower but higher quality)")
+    else:
+        logging.info("Using small images (faster)")
+
+    asyncio.run(import_cards(small_images=use_small))
+    logging.info("Import completed")


### PR DESCRIPTION
## 📝 Description

Added a development utility for importing sample card data to assist in local testing.
1. A new db:import-cards task in Taskfile.yml to run the import script
2. A cards_data.json file containing sample Pokémon card data with image URLs
3. An import_cards.py script that:
- Fetches images from URLs
- Generates perceptual hashes via our image_hash_service
- Stores card_id/hash pairs in the database

Related task : [IRS-7](https://sleeved.atlassian.net/browse/IRS-7)

## ✅ Checklist

* [ ] Code follows project standards (lint, format)
* [ ] Performance optimization verified (if applicable)
* [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

The script includes options to use either small or high-resolution images (task db:import-cards uses small images for speed, but you can modify to use high-res images if needed). The sample dataset contains 35 Pokémon base set cards to provide enough data for meaningful testing.


[IRS-7]: https://sleeved.atlassian.net/browse/IRS-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ